### PR TITLE
RELEASE 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGE LOG
 
+## [1.5.3] - 2023-12-23
+
+### Added
+- Added a mode to directly evaluate RPN expressions from the command line. For example, execute as follows:
+  ~~~ bash
+  stacker -e "3 4 + echo"
+  7
+  ~~~
+
+### Fixed
+- Fixed an issue where the processing of a plugin-added operator was not reflected when it overlapped with an existing operator.
+
+
+
 ## [1.5.2] - 2023-12-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ Stacker allows for straightforward RPN input. For example:
     ```
     This defines a macro with the body `{2 ^ 3 * 5 +}` and assigns it the name `calculatePowerAndAdd`. This macro squares the number on the stack, multiplies it by 3, and then adds 5.
 
+- #### Include Scripts
+  Stacker scripts can be included in other scripts using the `include` command. For example:
+
+  ``` bash
+  stacker:0>  "my_script.stk" include
+  ```
+  All functions, macros and variables defined in "my_script.stk" are added to the current stack.
+
 
 ### Running Scripts
 Stacker scripts can be created in *stk files. To run a script, simply execute it with Stacker. For example:
@@ -202,13 +210,13 @@ Stacker scripts can be created in *stk files. To run a script, simply execute it
   stacker my_script.stk
   ```
 
-### Include Scripts
-Stacker scripts can be included in other scripts using the `include` command. For example:
 
-``` bash
-stacker:0>  "my_script.stk" include
+### Command Line Execution
+You can directly execute a specified RPN expression from the command line.
+
+```bash
+stacker -e "3 4 + echo"
 ```
-All functions, macros and variables defined in "my_script.stk" are added to the current stack.
 
 
 ## Creating Plugins

--- a/README_JP.md
+++ b/README_JP.md
@@ -257,6 +257,14 @@ StackerのRPN入力の例を示します
     マクロ `{2 ^ 3 * 5 +}` を定義し、名前 `calculatePowerAndAdd` を割り当てます。このマクロは、スタック上の数値を2乗し、3倍し、5を加算します。
 
 
+- #### スクリプトのインクルード
+  Stackerスクリプトは、`include`コマンドを使用して他のスクリプトをインクルードできます。
+  ``` bash
+  stacker:0>  "my_script.stk" include
+  ```
+  "my_script.stk"で定義されたすべての関数とマクロと変数が現在のスタックに追加されます。
+
+
 
 - #### 逆ポーランドなんてクソ喰らえだ
     
@@ -272,6 +280,7 @@ StackerのRPN入力の例を示します
     ~~~ bash
     > pip uninstall pystacker
     ~~~
+
 
 ### スクリプトの実行
 Stackerスクリプトは*stkファイルで作成できます。スクリプトを実行するには、次の様に実行ファイルを指定します。
@@ -293,13 +302,13 @@ Stackerスクリプトは*stkファイルで作成できます。スクリプト
     stacker my_script.stk
     ```
 
-### スクリプトのインクルード
+### コマンドライン実行
+コマンドラインから、指定したRPN式を直接実行できます。
 
-Stackerスクリプトは、`include`コマンドを使用して他のスクリプトをインクルードできます。
-``` bash
-stacker:0>  "my_script.stk" include
+```bash
+stacker -e "3 4 + echo"
 ```
-"my_script.stk"で定義されたすべての関数とマクロと変数が現在のスタックに追加されます。
+
 
 
 ## プラグインの作成

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("requirements.txt", "r", encoding="utf-8") as f:
 setup(
     author="remokasu",
     name="pystacker",
-    version="1.5.2",
+    version="1.5.3",
     license=license,
     url="https://github.com/remokasu/stacker",
     install_requires=install_requires,

--- a/stacker/data/help.txt
+++ b/stacker/data/help.txt
@@ -10,10 +10,10 @@ Usage:
 
 Examples:
   RPN expression: 3 4 +
-  Variable assignment: 5 a set
-  Function definition: (x y) {x y ^ } funcName defun
+  Variable assignment: 5 $a set
+  Function definition: (x y) {x y ^ } $funcName defun
   Function call: 4 5 func
-  Macro definition: {2 ^ 5 +} macroName alias
+  Macro definition: {2 ^ 5 +} $macroName alias
   Macro call: 3 macroName
 
 Numbwer input
@@ -25,7 +25,7 @@ Numbwer input
   octal: 0o123
   complex: 1+2j
 String input:
-  hogefoovar
+  "hogefoovar"
   "hoge foo var"
 Array input:
   [1 2 3 4 5]

--- a/stacker/exec_modes/__init__.py
+++ b/stacker/exec_modes/__init__.py
@@ -1,5 +1,6 @@
+from stacker.exec_modes.commandline_mode import CommandLineMode
 from stacker.exec_modes.excution_mode import ExecutionMode
 from stacker.exec_modes.repl_mode import ReplMode
 from stacker.exec_modes.script_mode import ScriptMode
 
-__all__ = ["ExecutionMode", "ReplMode", "ScriptMode"]
+__all__ = ["ExecutionMode", "ReplMode", "ScriptMode", "CommandLineMode"]

--- a/stacker/exec_modes/commandline_mode.py
+++ b/stacker/exec_modes/commandline_mode.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from stacker.exec_modes.excution_mode import ExecutionMode
+
+
+class CommandLineMode(ExecutionMode):
+    def run(self, expression: str):
+        self.rpn_calculator.eval(expression)

--- a/stacker/exec_modes/repl_mode.py
+++ b/stacker/exec_modes/repl_mode.py
@@ -10,7 +10,7 @@ from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.history import FileHistory
 
 from stacker.exec_modes.excution_mode import ExecutionMode
-from stacker.lib import delete_history, show_about, show_help, show_top
+from stacker.lib import delete_history, show_about, show_help
 from stacker.lib.config import history_file_path
 from stacker.syntax.parser import (
     is_array,
@@ -40,7 +40,6 @@ class ReplMode(ExecutionMode):
             sys.exit()
 
     def run(self):
-        show_top()
         stacker_version = get_distribution("pystacker").version
         print(f"Stacker {stacker_version} on {sys.platform}")
         print('Type "help" to get more information.')

--- a/stacker/lib/function/eval.py
+++ b/stacker/lib/function/eval.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from stacker.error import StackerSyntaxError
 
-
 # def _stacker_eval(expr: str, stacker: "Stacker"):
 #     """Evaluates a given RPN expression.
 #     Returns the result of the evaluation.

--- a/stacker/plugins/matrix.py
+++ b/stacker/plugins/matrix.py
@@ -20,48 +20,19 @@ def is_matrix_or_vector(value):
 
 
 def matrix_add(a, b):
-    if is_matrix_or_vector(a) and is_matrix_or_vector(b):
-        return np.add(a, b).tolist()
-    elif not is_matrix_or_vector(a) and not is_matrix_or_vector(b):
-        return a + b
-    else:
-        raise ValueError(
-            "Both operands must be matrices (or vectors) for matrix addition."
-        )
+    return (np.array(a) + np.array(b)).tolist()
 
 
 def matrix_sub(a, b):
-    if is_matrix_or_vector(a) and is_matrix_or_vector(b):
-        return np.subtract(a, b).tolist()
-    elif not is_matrix_or_vector(a) and not is_matrix_or_vector(b):
-        return a - b
-    else:
-        raise ValueError(
-            "Both operands must be matrices (or vectors) for matrix subtraction."
-        )
+    return (np.array(a) - np.array(b)).tolist()
 
 
 def matrix_mul(a, b):
-    if is_matrix_or_vector(a) and is_matrix_or_vector(b):
-        return np.matmul(a, b).tolist()
-    elif not is_matrix_or_vector(a) and not is_matrix_or_vector(b):
-        return a * b
-    else:
-        raise ValueError(
-            "Both operands must be matrices (or vectors) for matrix multiplication."
-        )
-
-
-def elementwise_mul(a, b):
-    return np.multiply(a, b).tolist()
+    return (np.array(a) * np.array(b)).tolist()
 
 
 def elementwise_div(a, b):
-    return np.divide(a, b).tolist()
-
-
-def elementwise_div_inv(a, b):
-    return np.divide(b, a).tolist()
+    return (np.array(a) / np.array(b)).tolist()
 
 
 def matrix_transpose(a):
@@ -117,9 +88,7 @@ def setup(stacker: Stacker):
     stacker.register_plugin("+", matrix_add, desc=description)
     stacker.register_plugin("-", matrix_sub, desc=description)
     stacker.register_plugin("*", matrix_mul, desc=description)
-    stacker.register_plugin(".*", elementwise_mul, desc=description)
-    stacker.register_plugin("./", elementwise_div, desc=description)
-    stacker.register_plugin(".\\", elementwise_div_inv, desc=description)
+    stacker.register_plugin("/", elementwise_div, desc=description)
     stacker.register_plugin("'", matrix_transpose, desc=description)
     stacker.register_plugin("inv", matrix_inverse, desc=description)
     stacker.register_plugin("det", matrix_determinant, desc=description)

--- a/test/plugin_test/test_matrix_operations_plugin.py
+++ b/test/plugin_test/test_matrix_operations_plugin.py
@@ -12,76 +12,76 @@ class TestMatrixOperationsPlugin(unittest.TestCase):
         matrix.setup(self.stacker)
 
     def test_matrix_add(self):
-        a = [[1, 2], [3, 4]]
-        b = [[5, 6], [7, 8]]
+        a = np.array([[1, 2], [3, 4]])
+        b = np.array([[5, 6], [7, 8]])
         expression = "[1 2; 3 4] [5 6; 7 8] +"
         self.stacker.stack.clear()
         self.stacker.process_expression(expression)
-        expected_result = np.add(a, b).tolist()
+        expected_result = (a + b).tolist()
         self.assertEqual(self.stacker.stack[-1], expected_result)
         print("\n")
         print(f"expression: {expression}")
         print(f"result: {self.stacker.stack[-1]}")
 
     def test_matrix_sub(self):
-        a = [[1, 2], [3, 4]]
-        b = [[5, 6], [7, 8]]
+        a = np.array([[1, 2], [3, 4]])
+        b = np.array([[5, 6], [7, 8]])
         expression = "[1 2; 3 4] [5 6; 7 8] -"
         self.stacker.stack.clear()
         self.stacker.process_expression(expression)
-        expected_result = np.subtract(a, b).tolist()
+        expected_result = (a - b).tolist()
         self.assertEqual(self.stacker.stack[-1], expected_result)
         print("\n")
         print(f"expression: {expression}")
         print(f"result: {self.stacker.stack[-1]}")
 
     def test_matrix_mul(self):
-        a = [[1, 2], [3, 4]]
-        b = [[5, 6], [7, 8]]
+        a = np.array([[1, 2], [3, 4]])
+        b = np.array([[5, 6], [7, 8]])
         expression = "[1 2; 3 4] [5 6; 7 8] *"
         self.stacker.stack.clear()
         self.stacker.process_expression(expression)
-        expected_result = np.matmul(a, b).tolist()
+        expected_result = (a * b).tolist()
         self.assertEqual(self.stacker.stack[-1], expected_result)
         print("\n")
         print(f"expression: {expression}")
         print(f"result: {self.stacker.stack[-1]}")
 
-    def test_elementwise_mul(self):
-        a = [[1, 2], [3, 4]]
-        b = [[5, 6], [7, 8]]
-        expression = "[1 2; 3 4] [5 6; 7 8] .*"
-        self.stacker.stack.clear()
-        self.stacker.process_expression(expression)
-        expected_result = np.multiply(a, b).tolist()
-        self.assertEqual(self.stacker.stack[-1], expected_result)
-        print("\n")
-        print(f"expression: {expression}")
-        print(f"result: {self.stacker.stack[-1]}")
+    # def test_elementwise_mul(self):
+    #     a = [[1, 2], [3, 4]]
+    #     b = [[5, 6], [7, 8]]
+    #     expression = "[1 2; 3 4] [5 6; 7 8] .*"
+    #     self.stacker.stack.clear()
+    #     self.stacker.process_expression(expression)
+    #     expected_result = np.multiply(a, b).tolist()
+    #     self.assertEqual(self.stacker.stack[-1], expected_result)
+    #     print("\n")
+    #     print(f"expression: {expression}")
+    #     print(f"result: {self.stacker.stack[-1]}")
 
-    def test_elementwise_div(self):
-        a = [[1, 2], [3, 4]]
-        b = [[5, 6], [7, 8]]
-        expression = "[1 2; 3 4] [5 6; 7 8] ./"
-        self.stacker.stack.clear()
-        self.stacker.process_expression(expression)
-        expected_result = np.divide(a, b).tolist()
-        self.assertEqual(self.stacker.stack[-1], expected_result)
-        print("\n")
-        print(f"expression: {expression}")
-        print(f"result: {self.stacker.stack[-1]}")
+    # def test_elementwise_div(self):
+    #     a = [[1, 2], [3, 4]]
+    #     b = [[5, 6], [7, 8]]
+    #     expression = "[1 2; 3 4] [5 6; 7 8] ./"
+    #     self.stacker.stack.clear()
+    #     self.stacker.process_expression(expression)
+    #     expected_result = np.divide(a, b).tolist()
+    #     self.assertEqual(self.stacker.stack[-1], expected_result)
+    #     print("\n")
+    #     print(f"expression: {expression}")
+    #     print(f"result: {self.stacker.stack[-1]}")
 
-    def test_elementwise_div_inv(self):
-        a = [[1, 2], [3, 4]]
-        b = [[5, 6], [7, 8]]
-        expression = "[1 2; 3 4] [5 6; 7 8] .\\"
-        self.stacker.stack.clear()
-        self.stacker.process_expression(expression)
-        expected_result = np.divide(b, a).tolist()
-        self.assertEqual(self.stacker.stack[-1], expected_result)
-        print("\n")
-        print(f"expression: {expression}")
-        print(f"result: {self.stacker.stack[-1]}")
+    # def test_elementwise_div_inv(self):
+    #     a = [[1, 2], [3, 4]]
+    #     b = [[5, 6], [7, 8]]
+    #     expression = "[1 2; 3 4] [5 6; 7 8] .\\"
+    #     self.stacker.stack.clear()
+    #     self.stacker.process_expression(expression)
+    #     expected_result = np.divide(b, a).tolist()
+    #     self.assertEqual(self.stacker.stack[-1], expected_result)
+    #     print("\n")
+    #     print(f"expression: {expression}")
+    #     print(f"result: {self.stacker.stack[-1]}")
 
     def test_matrix_transpose(self):
         a = [[1, 2], [3, 4]]
@@ -132,7 +132,7 @@ class TestMatrixOperationsPlugin(unittest.TestCase):
         expression = "[1 2; 3 4] trace"
         self.stacker.stack.clear()
         self.stacker.process_expression(expression)
-        expected_result = np.trace(a)
+        expected_result = np.trace(a).tolist()
         self.assertEqual(self.stacker.stack[-1], expected_result)
         print("\n")
         print(f"expression: {expression}")


### PR DESCRIPTION
- Added a mode to directly evaluate RPN expressions from the command line. For example, execute as follows: stacker -e "3 4 + echo"

- Fixed an issue where the processing of a plugin-added operator was not reflected when it overlapped with an existing operator.

close #14 