### PR TITLE
RELEASE 1.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # CHANGE LOG
 
+## [1.5.9] - 2024-09-16
+- Fixed the `eval` command. Previously used solely for evaluating strings, it can now also evaluate block stacks and literal objects.
+  - Examples:
+    ```
+    stacker:0> {1 2 +} eval
+    [3]
+    ```
+    In this example, the block stack `{1 2 +}` is evaluated, and the result is pushed onto the stack.
+
+    ```
+    stacker:0> 3 eval
+    [3]
+    ```
+    In this example, the literal object `3` is evaluated, and the result is pushed onto the stack.
+
+- Removed the feature introduced in 1.5.8 that displayed a specific error message (StackUnderflowError) when the stack depth is less than the number of function arguments. Errors occurring during evaluation will now display as before.
+
+
 ## [1.5.8] - 2024-09-14
 - Fixed a bug where empty blocks `{}` were not being evaluated properly.
 - Added `iferror` command.
@@ -8,6 +26,12 @@
     {try block} {catch block} iferror
     ~~~
 
+- Introduced a dedicated error message when the stack depth is less than the number of arguments required by a function.
+  - Example:
+    ```
+    stacker:0> 1 +
+    StackUnderflowError: Operator `+` requires 2 arguments.
+    ```
 
 ## [1.5.7] - 2024-09-08
 - Fixed an issue where stack-related commands were inadvertently removed from input suggestions in version 1.5.6. These commands are now correctly displayed in suggestions.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("requirements.txt", "r", encoding="utf-8") as f:
 setup(
     author="remokasu",
     name="pystacker",
-    version="1.5.8",
+    version="1.5.9",
     license=license,
     url="https://github.com/remokasu/stacker",
     install_requires=install_requires,

--- a/stacker/lib/function/types.py
+++ b/stacker/lib/function/types.py
@@ -17,6 +17,7 @@ def _float(x):
 
 def _str(x):
     try:
+        print(x)
         return str(x)
     except TypeError:
         raise TypeError(f"Cannot take str of {x}.")

--- a/stacker/syntax/parser.py
+++ b/stacker/syntax/parser.py
@@ -161,6 +161,12 @@ def is_string(expression: str) -> bool:
     )
 
 
+def is_list(expression: str) -> bool:
+    if not isinstance(expression, str):
+        return False
+    return expression.startswith("[") and expression.endswith("]")
+
+
 def is_undefined_symbol(expression: str) -> bool:
     return expression.startswith("$") and not expression.endswith("$")
 

--- a/test/test_block.py
+++ b/test/test_block.py
@@ -4,6 +4,7 @@ from stacker.stacker import Stacker
 from stacker.sfunction import StackerFunction
 from stacker.syntax.parser import parse_expression
 
+
 class TestUnit(unittest.TestCase):
     def test_enmpty_block(self):
         stacker = Stacker()
@@ -13,17 +14,17 @@ class TestUnit(unittest.TestCase):
             assert True
         except Exception as e:
             assert False, e
-    
+
         assert stacker.stack[0].get_expression() == ""
 
     def test_block(self):
         stacker = Stacker()
         expr = "{0}"
         stacker.process_expression(expr)
-        assert stacker.stack[0].get_expression() == '0'
+        assert stacker.stack[0].get_expression() == "0"
 
     def test_block2(self):
         stacker = Stacker()
         expr = "{0 1 +}"
         stacker.process_expression(expr)
-        assert stacker.stack[0].get_expression() == '0 1 +'
+        assert stacker.stack[0].get_expression() == "0 1 +"

--- a/test/test_if_else_statement.py
+++ b/test/test_if_else_statement.py
@@ -80,7 +80,7 @@ class TestUnit(unittest.TestCase):
         stacker = Stacker()
         expr = "{1 +} {99} iferror"
         stacker.process_expression(expr)
-        self.assertEqual(list(stacker.stack), [1, 99])
+        self.assertEqual(list(stacker.stack), [99])
 
         # no error
         stacker = Stacker()

--- a/test/test_operator.py
+++ b/test/test_operator.py
@@ -306,10 +306,23 @@ class TestStacker(unittest.TestCase):
         self.assertEqual(self.stacker.stack[-1], 28)
 
     # eval
-    def test_eval(self):
+    def test_eval_str(self):
         self.stacker.stack.clear()
         self.stacker.process_expression("'3 5 +' eval")
         self.assertEqual(self.stacker.stack[-1], 8)
+
+        self.stacker.stack.clear()
+        self.stacker.process_expression("5 eval")
+        self.assertEqual(self.stacker.stack[-1], 5)
+
+    def test_eval_block(self):
+        self.stacker.stack.clear()
+        self.stacker.process_expression("{3 5 +} eval")
+        self.assertEqual(self.stacker.stack[-1], 8)
+
+        self.stacker.stack.clear()
+        self.stacker.process_expression("{3 5} {*} eval")
+        self.assertEqual(self.stacker.stack[-1], 15)
 
     # evalpy
     def test_evalpy(self):


### PR DESCRIPTION
- Fixed the `eval` command. Previously used solely for evaluating strings, it can now also evaluate block stacks and literal objects.
  - Examples: 
    ```
    stacker:0> {1 2 +} eval [3] 
    ```
    In this example, the block stack `{1 2 +}` is evaluated, and the result is pushed onto the stack.

    ```
    stacker:0> 3 eval [3]
    ```
    In this example, the literal object `3` is evaluated, and the result is pushed onto the stack.

- Removed the feature introduced in 1.5.8 that displayed a specific error message (StackUnderflowError) when the stack depth is less than the number of function arguments. Errors occurring during evaluation will now display as before.