### PR TITLE
RELEASE 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGE LOG
 
+## [1.6.1]
+
+### Bug Fixes
+- Resolved an issue where passing arrays to user-defined functions resulted in errors.
+
+### Breaking Changes
+- Changed the macro definition command from `alias` to `defmacro`.
+  - Rationale: This change aligns the macro definition syntax with the function definition syntax (`defun`).
+  - Note: This modification is not backwards compatible with previous versions.
+
+### Migration
+Users will need to update their existing macro definitions:
+- Old syntax: `alias`
+- New syntax: `defmacro`
+
+
 ## [1.6.0]
 
 ### Feature Changes

--- a/README.md
+++ b/README.md
@@ -304,11 +304,11 @@ Stacker allows for straightforward RPN input. For example:
 - ### Define a macro:
   - syntax:
     ```bash
-    {body} $name alias
+    {body} $name defmacro
     ```
   - example:
     ```bash
-    stacker:0> {2 ^ 3 * 5 +} $calculatePowerAndAdd alias
+    stacker:0> {2 ^ 3 * 5 +} $calculatePowerAndAdd defmacro
     stacker:1> 5 calculatePowerAndAdd
     [80]
     ```
@@ -616,7 +616,7 @@ print(stacker.eval("3 4 +"))
 | Operator | Description                                           | Example                    |
 |----------|-------------------------------------------------------|----------------------------|
 | defun    | Define a function                                     | `{x y} {x y *} $multiply defun` |
-| alias    | Define a macro                                        | `{2 ^ 3 * 5 +} $calculatePowerAndAdd alias` |
+| defmacro    | Define a macro                                        | `{2 ^ 3 * 5 +} $calculatePowerAndAdd defmacro` |
 | set      | Assign a value to a variable                          | `3 $x set`                |
 
 

--- a/examples/ex04.stk
+++ b/examples/ex04.stk
@@ -2,7 +2,7 @@
 "func.stk" include
 
 {x y} {x y +} $fadd defun
-{* 10 +} $mulmacro alias
+{* 10 +} $mulmacro defmacro
 
 4 oneadd echo
 5 power echo

--- a/examples/macro.stk
+++ b/examples/macro.stk
@@ -1,1 +1,1 @@
-{1 +} $oneadd alias
+{1 +} $oneadd defmacro

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("requirements.txt", "r", encoding="utf-8") as f:
 setup(
     author="remokasu",
     name="pystacker",
-    version="1.6.0",
+    version="1.6.1",
     license=license,
     url="https://github.com/remokasu/stacker",
     install_requires=install_requires,

--- a/stacker/data/help.txt
+++ b/stacker/data/help.txt
@@ -13,7 +13,7 @@ Examples:
   Variable assignment: 5 $a set
   Function definition: {x y} {x y ^ } $funcName defun
   Function call: 4 5 func
-  Macro definition: {2 ^ 5 +} $macroName alias
+  Macro definition: {2 ^ 5 +} $macroName defmacro
   Macro call: 3 macroName
 
 Numbwer input

--- a/stacker/lib/function/defmacro.py
+++ b/stacker/lib/function/defmacro.py
@@ -15,7 +15,7 @@ def define_macro(stacker: Stacker, name: str, body: Stacker) -> None:
 
 
 macro_operators = {
-    "alias": {
+    "defmacro": {
         "func": (lambda stacker, name, body: define_macro(stacker, name, body)),
         "arg_count": 2,
         "push_result_to_stack": False,

--- a/stacker/slib/sfunction.stk
+++ b/stacker/slib/sfunction.stk
@@ -2,4 +2,4 @@
 """
 mean: Mean of a list of numbers
 """
-$xs {xs sum xs len /} $mean defun
+{xs} {xs sum xs len /} $mean defun

--- a/test/src_test/test.stk
+++ b/test/src_test/test.stk
@@ -1,2 +1,2 @@
 {x} {x 2 ^} $power defun
-{1 +} $increment alias
+{1 +} $increment defmacro

--- a/test/test_defmacro.py
+++ b/test/test_defmacro.py
@@ -1,0 +1,14 @@
+import unittest
+
+from stacker.stacker import Stacker
+
+
+class TestStacker(unittest.TestCase):
+    def setUp(self):
+        self.stacker = Stacker()
+
+    def test_macro_definition_and_call_1(self):
+        self.stacker.stack.clear()
+        self.stacker.eval("{4 +} $add defmacro")
+        ans = self.stacker.eval("3 add")
+        self.assertEqual(ans[-1], 7)

--- a/test/test_defun.py
+++ b/test/test_defun.py
@@ -1,0 +1,32 @@
+import unittest
+
+from stacker.stacker import Stacker
+
+
+class TestStacker(unittest.TestCase):
+    def setUp(self):
+        self.stacker = Stacker()
+
+    def test_function_definition_and_call_1(self):
+        self.stacker.stack.clear()
+        self.stacker.eval("{x} {x 2 + x 3 * +} $f defun")
+        ans = self.stacker.eval("4 f")
+        self.assertEqual(ans[-1], 18)
+
+    def test_function_definition_and_call_2(self):
+        self.stacker.stack.clear()
+        self.stacker.eval("{xs} {xs sum} $test_sum defun")
+        ans = self.stacker.eval("[1 2 3] test_sum")
+        self.assertEqual(ans[-1], 6)
+
+    def test_function_definition_and_call_3(self):
+        self.stacker.stack.clear()
+        self.stacker.eval("{xs} {xs sum} $test_sum defun")
+        ans = self.stacker.eval("{[4 5 6]} test_sum")
+        self.assertEqual(ans[-1], 15)
+
+    def test_function_definition_and_call_4(self):
+        self.stacker.stack.clear()
+        self.stacker.eval("{xs} {xs sum} $test_sum defun")
+        ans = self.stacker.eval("{(7 8 9)} test_sum")
+        self.assertEqual(ans[-1], 24)


### PR DESCRIPTION
Bug Fixes
- Resolved an issue where passing arrays to user-defined functions resulted in errors.

Breaking Changes
- Changed the macro definition command from `alias` to `defmacro`.
  - Rationale: This change aligns the macro definition syntax with the function definition syntax (`defun`).
  - Note: This modification is not backwards compatible with previous versions.

Migration
Users will need to update their existing macro definitions:
- Old syntax: `alias`
- New syntax: `defmacro`